### PR TITLE
Update Dockerfile

### DIFF
--- a/ovs_build/Dockerfile
+++ b/ovs_build/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update -y
-RUN apt-get install -y sudo
+RUN apt-get update -y && apt-get install -y sudo
 RUN rm -rf /lib/modules
 RUN apt-get install -y linux-headers-4.4.0-45-generic
 RUN ln -s /lib/modules/4.4.0-45-generic /lib/modules/`uname -r`


### PR DESCRIPTION
The command sudo could not install due to problems in the cache registry. I have solved this through sorting the installation commands as recommended by [https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/].